### PR TITLE
Removed most warnings from JUnit tests and unused imports from classes

### DIFF
--- a/src/ijordan/matrixonator/model/Matrix.java
+++ b/src/ijordan/matrixonator/model/Matrix.java
@@ -1,7 +1,6 @@
 package ijordan.matrixonator.model;
 
 import java.time.LocalDate;
-import java.util.Arrays;
 
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;

--- a/src/ijordan/matrixonator/model/RREFMatrix.java
+++ b/src/ijordan/matrixonator/model/RREFMatrix.java
@@ -1,7 +1,5 @@
 package ijordan.matrixonator.model;
 
-import java.util.Arrays;
-
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 

--- a/src/ijordan/matrixonatorTest/MatrixTest.java
+++ b/src/ijordan/matrixonatorTest/MatrixTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDate;
+import java.util.Arrays;
 
 import ijordan.matrixonator.model.*;
 
@@ -102,8 +103,6 @@ public class MatrixTest {
 		assertTrue("Matrix data in invalid", result);
 	}
 
-	
-
 	/*
 	 * ------------ Matrix Arithmetic Tests ----------------------------------
 	 */
@@ -119,9 +118,10 @@ public class MatrixTest {
 				null);
 		assertTrue("Matrices should be compatible",
 				Matrix.checkMultCompatibility(testMatrix1, testMatrix2));
-		assertEquals("Matrix Multiplication gives incorrect result",
-				testMatrixResult.getData(),
-				Matrix.multiplyMatrices(testMatrix1, testMatrix2).getData());
+
+		assertTrue("Matrix Multiplication gives incorrect result",
+				Arrays.deepEquals(testMatrixResult.getData(), Matrix
+						.multiplyMatrices(testMatrix1, testMatrix2).getData()));
 	}
 
 	@Test
@@ -137,9 +137,9 @@ public class MatrixTest {
 		assertTrue("Matrices should be compatible",
 				Matrix.checkMultCompatibility(testMatrix1, testMatrix2));
 
-		assertEquals("Matrix Multiplication gives incorrect result",
-				testMatrixResult.getData(),
-				Matrix.multiplyMatrices(testMatrix1, testMatrix2).getData());
+		assertTrue("Matrix Multiplication gives incorrect result",
+				Arrays.deepEquals(testMatrixResult.getData(), Matrix
+						.multiplyMatrices(testMatrix1, testMatrix2).getData()));
 	}
 
 	@Test
@@ -161,9 +161,9 @@ public class MatrixTest {
 		assertTrue("Matrices should be compatible",
 				Matrix.checkMultCompatibility(testMatrix1, testMatrix2));
 
-		assertEquals("Matrix Multiplication gives incorrect result",
-				testMatrixResult.getData(),
-				Matrix.multiplyMatrices(testMatrix1, testMatrix2).getData());
+		assertTrue("Matrix Multiplication gives incorrect result",
+				Arrays.deepEquals(testMatrixResult.getData(), Matrix
+						.multiplyMatrices(testMatrix1, testMatrix2).getData()));
 
 	}
 
@@ -191,9 +191,9 @@ public class MatrixTest {
 		final Matrix testMatrix2 = new Matrix("Test2", dataSecond, null);
 		final Matrix testMatrixResult = new Matrix("TestResult", dataResult,
 				null);
-		assertEquals("Matrix Addition gives incorrect result",
+		assertTrue("Matrix Addition gives incorrect result", Arrays.deepEquals(
 				testMatrixResult.getData(),
-				Matrix.addMatrices(testMatrix1, testMatrix2).getData());
+				Matrix.addMatrices(testMatrix1, testMatrix2).getData()));
 	}
 
 	@Test
@@ -205,9 +205,9 @@ public class MatrixTest {
 		final Matrix testMatrix2 = new Matrix("Test2", dataSecond, null);
 		final Matrix testMatrixResult = new Matrix("TestResult", dataResult,
 				null);
-		assertEquals("Matrix Addition gives incorrect result",
+		assertTrue("Matrix Addition gives incorrect result", Arrays.deepEquals(
 				testMatrixResult.getData(),
-				Matrix.addMatrices(testMatrix1, testMatrix2).getData());
+				Matrix.addMatrices(testMatrix1, testMatrix2).getData()));
 	}
 
 	@Test
@@ -225,9 +225,9 @@ public class MatrixTest {
 		final Matrix testMatrixResult = new Matrix("TestResult", dataResult,
 				null);
 
-		assertEquals("Matrix Addition gives incorrect result",
+		assertTrue("Matrix Addition gives incorrect result", Arrays.deepEquals(
 				testMatrixResult.getData(),
-				Matrix.addMatrices(testMatrix1, testMatrix2).getData());
+				Matrix.addMatrices(testMatrix1, testMatrix2).getData()));
 
 	}
 }

--- a/src/ijordan/matrixonatorTest/RREFMatrixTest.java
+++ b/src/ijordan/matrixonatorTest/RREFMatrixTest.java
@@ -1,13 +1,16 @@
 package ijordan.matrixonatorTest;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+
 import ijordan.matrixonator.model.Matrix;
 import ijordan.matrixonator.model.RREFMatrix;
 
 import org.junit.Test;
 
 public class RREFMatrixTest {
-	
+
 	/*
 	 * -------------------------- Matrix Reduction Tests -------------------
 	 */
@@ -17,20 +20,22 @@ public class RREFMatrixTest {
 		double[][] data = { { 1, 0, 3, 3 }, { 0, 1, 0, 4 }, { 0, 0, 0, 1 } };
 		double[][] dataResult = { { 1, 0, 3, 0 }, { 0, 1, 0, 0 },
 				{ 0, 0, 0, 1 } };
-		final RREFMatrix testMatrix = new RREFMatrix(new Matrix("Test", data, null));
+		final RREFMatrix testMatrix = new RREFMatrix(new Matrix("Test", data,
+				null));
 
-		assertEquals("Matrix Reduction gives incorrect result", dataResult,
-				testMatrix.getData());
+		assertTrue("Matrix Reduction gives incorrect result",
+				Arrays.deepEquals(dataResult, testMatrix.getData()));
 	}
 
 	@Test
 	public void testMatrixReduceNormal2() {
 		double[][] data = { { 15, 3, 6 }, { 0, 3, 6 } };
 		double[][] dataResult = { { 1, 0, 0 }, { 0, 1, 2 } };
-		final RREFMatrix testMatrix = new RREFMatrix(new Matrix("Test", data, null));
+		final RREFMatrix testMatrix = new RREFMatrix(new Matrix("Test", data,
+				null));
 
-		assertEquals("Matrix Reduction gives incorrect result", dataResult,
-				testMatrix.getData());
+		assertTrue("Matrix Reduction gives incorrect result",
+				Arrays.deepEquals(dataResult, testMatrix.getData()));
 	}
 
 	@Test
@@ -39,20 +44,22 @@ public class RREFMatrixTest {
 				{ 1, 3, 2, 4 }, { 0, 1, 2, 3 }, { 5, 6, 7, 8 } };
 		double[][] dataResult = { { 1, 0, 0, 0 }, { 0, 1, 0, 0 },
 				{ 0, 0, 1, 0 }, { 0, 0, 0, 1 }, { 0, 0, 0, 0 }, { 0, 0, 0, 0 } };
-		final RREFMatrix testMatrix = new RREFMatrix(new Matrix("Test", data, null));
+		final RREFMatrix testMatrix = new RREFMatrix(new Matrix("Test", data,
+				null));
 
-		assertEquals("Matrix Reduction gives incorrect result", dataResult,
-				testMatrix.getData());
+		assertTrue("Matrix Reduction gives incorrect result",
+				Arrays.deepEquals(dataResult, testMatrix.getData()));
 	}
 
 	@Test
 	public void testMatrixReduceNegative() {
 		double[][] data = { { 1, 2, 1 }, { -2, -3, 1 }, { 3, 5, 0 } };
 		double[][] dataResult = { { 1, 0, -5 }, { 0, 1, 3 }, { 0, 0, 0 } };
-		final RREFMatrix testMatrix = new RREFMatrix(new Matrix("Test", data, null));
+		final RREFMatrix testMatrix = new RREFMatrix(new Matrix("Test", data,
+				null));
 
-		assertEquals("Matrix Reduction gives incorrect result", dataResult,
-				testMatrix.getData());
+		assertTrue("Matrix Reduction gives incorrect result",
+				Arrays.deepEquals(dataResult, testMatrix.getData()));
 	}
 
 	@Test
@@ -61,30 +68,31 @@ public class RREFMatrixTest {
 				{ 8765, 123, 765, 234 }, { 5736, 4736, 27364, 5 } };
 		double[][] dataResult = { { 1, 0, 0, 0 }, { 0, 1, 0, 0 },
 				{ 0, 0, 1, 0 }, { 0, 0, 0, 1 } };
-		final RREFMatrix testMatrix = new RREFMatrix(new Matrix("Test", data, null));
+		final RREFMatrix testMatrix = new RREFMatrix(new Matrix("Test", data,
+				null));
 
-		assertEquals("Matrix Reduction gives incorrect result", dataResult,
-				testMatrix.getData());
+		assertTrue("Matrix Reduction gives incorrect result",
+				Arrays.deepEquals(dataResult, testMatrix.getData()));
 	}
-	
+
 	@Test
 	public void testERO1() {
 		double[][] data = { { 1, 2, 1 }, { -2, -3, 1 }, { 3, 5, 0 } };
 		double[][] dataResult = { { 1, 2, 1 }, { 3, 5, 0 }, { -2, -3, 1 } };
 		final Matrix testMatrix = new Matrix("Test", data, null);
 
-		assertEquals("Matrix ERO1 gives incorrect result", dataResult,
-				RREFMatrix.ERO1(testMatrix, 2, 1).getData());
+		assertTrue("Matrix ERO1 gives incorrect result", Arrays.deepEquals(
+				dataResult, RREFMatrix.ERO1(testMatrix, 2, 1).getData()));
 	}
-	
+
 	@Test
 	public void testERO2Negative() {
 		double[][] data = { { 1, 2, 1 }, { -2, -3, 1 }, { 3, 5, 0 } };
 		double[][] dataResult = { { 1, 2, 1 }, { 2, 3, -1 }, { 3, 5, 0 } };
 		final Matrix testMatrix = new Matrix("Test", data, null);
 
-		assertEquals("Matrix ERO2 gives incorrect result", dataResult,
-				RREFMatrix.ERO2(testMatrix, 1, -1).getData());
+		assertTrue("Matrix ERO2 gives incorrect result", Arrays.deepEquals(
+				dataResult, RREFMatrix.ERO2(testMatrix, 1, -1).getData()));
 	}
 
 	@Test
@@ -93,8 +101,10 @@ public class RREFMatrixTest {
 		double[][] dataResult = { { 1, 2, 1 }, { -8, -13, 1 }, { 3, 5, 0 } };
 		final Matrix testMatrix = new Matrix("Test", data, null);
 
-		assertEquals("Matrix ERO3 gives incorrect result", dataResult,
-				RREFMatrix.ERO3(testMatrix, 1, 2, -2).getData());
+		assertTrue(
+				"Matrix ERO3 gives incorrect result",
+				Arrays.deepEquals(dataResult,
+						RREFMatrix.ERO3(testMatrix, 1, 2, -2).getData()));
 	}
 
 	@Test
@@ -104,8 +114,8 @@ public class RREFMatrixTest {
 		final Matrix testMatrix = new Matrix("Test", data, null);
 		RREFMatrix.stepOne(testMatrix, 1, 1);
 
-		assertEquals("Matrix stepOne gives incorrect result", dataResult,
-				testMatrix.getData());
+		assertTrue("Matrix stepOne gives incorrect result",
+				Arrays.deepEquals(dataResult, testMatrix.getData()));
 	}
 
 	@Test
@@ -117,8 +127,8 @@ public class RREFMatrixTest {
 		final Matrix testMatrix = new Matrix("Test", data, null);
 		RREFMatrix.stepOne(testMatrix, 2, 2);
 
-		assertEquals("Matrix stepOne gives incorrect result", dataResult,
-				testMatrix.getData());
+		assertTrue("Matrix stepOne gives incorrect result",
+				Arrays.deepEquals(dataResult, testMatrix.getData()));
 	}
 
 }


### PR DESCRIPTION
Thought this might make it look a bit nicer and stop my Eclipse from complaining all the time. Didn't bother with the stuff I wasn't sure about in the Controller and also left the load stuff with warnings cause I'm working on changing that anyway to a different class/method set.

For the JUnits, converts the assertEquals -> assertTrues. Used the Arrays.deepEquals to compare as .equals only works for 1D arrays. deepEquals compares correctly for 2D arrays.